### PR TITLE
Path with spaces

### DIFF
--- a/lib/utils/sys-script.js
+++ b/lib/utils/sys-script.js
@@ -4,7 +4,7 @@ const exec = require('child_process').exec
 
 function countLines (fullPath) {
   return new Promise((resolve, reject) => {
-    exec(`wc ${fullPath} -l`,
+    exec(`wc '${fullPath}' -l`,
       function (error, stdout, stderr) {
         if (error !== null) {
           return reject(new Error('error to count lines ' + stderr))
@@ -30,7 +30,7 @@ function readInterval (begin, end, fullPath) {
   begin++
   end++
   return new Promise((resolve, reject) => {
-    exec(`sed '${begin},${end}!d' ${fullPath}`,
+    exec(`sed '${begin},${end}!d' '${fullPath}'`,
       function (error, stdout, stderr) {
         if (error !== null) {
           return reject(new Error('error to count lines ' + stderr))


### PR DESCRIPTION
It allow file names with spaces. e.g: `important document.pdf`.